### PR TITLE
fix: update Husky pre-commit hook configuration

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,3 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 # Run Biome check
 pnpm biome:check || {
   echo '❌ Biome check failed. Please fix the issues and try committing again.'


### PR DESCRIPTION
This pull request includes a small change to the `.husky/pre-commit` file. The change removes the shebang line and the sourcing of the `husky.sh` script, simplifying the pre-commit hook to only run the Biome check.

* [`.husky/pre-commit`](diffhunk://#diff-d2bc4bbf14eadc292d84e0ef5f7a93115c23557f533809fc80b896934291529dL1-L3): Removed the shebang line and the sourcing of `husky.sh` script to simplify the pre-commit hook.