### PR TITLE
ci: github workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,14 +15,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: pnpm/action-setup@v4
+
       - uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
-
-      - uses: pnpm/action-setup@v4
+          cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
 
       - name: Run Semantic Release
         run: npx semantic-release

--- a/.github/workflows/studio.yml
+++ b/.github/workflows/studio.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Typecheck
-        run: pnpm --filter @sallypayne/studio typecheck
+      - name: Check types
+        run: pnpm --filter @sallypayne/studio types:check
 
       - name: Build studio
         run: pnpm --filter @sallypayne/studio build

--- a/.github/workflows/studio.yml
+++ b/.github/workflows/studio.yml
@@ -19,14 +19,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: pnpm/action-setup@v4
+
       - uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
-
-      - uses: pnpm/action-setup@v4
+          cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
 
       - name: Typecheck
         run: pnpm --filter @sallypayne/studio typecheck

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -26,14 +26,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: pnpm/action-setup@v4
+
       - uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
-
-      - uses: pnpm/action-setup@v4
+          cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
 
       - name: Typecheck
         run: pnpm --filter @sallypayne/web typecheck

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -36,8 +36,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Typecheck
-        run: pnpm --filter @sallypayne/web typecheck
+      - name: Check types
+        run: pnpm --filter @sallypayne/web types:check
 
-      - name: Build Website
+      - name: Build website
         run: pnpm --filter @sallypayne/web build


### PR DESCRIPTION
This pull request includes changes to the GitHub workflows for the release, studio, and website jobs. The updates streamline the setup and installation steps, as well as modify type-checking commands.

Improvements to workflows:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R18-R26): Moved the `pnpm/action-setup@v4` step to run before `actions/setup-node@v4` and removed the `--frozen-lockfile` option from the `pnpm install` command.
* [`.github/workflows/studio.yml`](diffhunk://#diff-8d500915a9d5da5d37db254d423bc95ad5bffdb59f685f8abb9ebb928f514dbbR22-R33): Moved the `pnpm/action-setup@v4` step to run before `actions/setup-node@v4`, removed the `--frozen-lockfile` option from the `pnpm install` command, and renamed the type-checking step to "Check types" with the updated command `pnpm --filter @sallypayne/studio types:check`.
* [`.github/workflows/website.yml`](diffhunk://#diff-c7731b29de71fca225e1dfac88ebe31975a4cd9759ab13e91d86eeadafbddc10R29-R42): Moved the `pnpm/action-setup@v4` step to run before `actions/setup-node@v4`, removed the `--frozen-lockfile` option from the `pnpm install` command, and renamed the type-checking step to "Check types" with the updated command `pnpm --filter @sallypayne/web types:check`.